### PR TITLE
Update empc_ftxt() to indicate 1 input limit

### DIFF
--- a/R/epmc_ftxt.r
+++ b/R/epmc_ftxt.r
@@ -1,6 +1,6 @@
-#' Fetch Europe PMC full texts
+#' Fetch Europe PMC full text
 #'
-#' This function loads full texts into R. Full texts are in XML format and are
+#' This function loads one full text into R. Full text is in XML format and is
 #' only provided for the Open Access subset of Europe PMC.
 #'
 #' @param ext_id character, PMCID. 
@@ -15,8 +15,8 @@
 #'   epmc_ftxt("PMC3639880")
 #'   }
 epmc_ftxt <- function(ext_id = NULL) {
-  if (!grepl("^PMC", ext_id))
-    stop("Please provide a PMCID, i.e. ids starting with 'PMC'")
+  if (!grepl("^PMC", ext_id) || length(ext_id) != 1)
+    stop("Please provide one PMCID, i.e. id starting with 'PMC'")
   # call api
   req <-
     httr::RETRY("GET",

--- a/tests/testthat/test_epmc_ftxt.r
+++ b/tests/testthat/test_epmc_ftxt.r
@@ -5,7 +5,7 @@ test_that("epmc_ftxt returns", {
   a <- epmc_ftxt("PMC3257301")
   b <- epmc_ftxt("PMC3639880")
 
-  #correct class metadata
+  # correct class metadata
   expect_is(a, "xml_document")
   expect_is(b, "xml_document")
 
@@ -13,6 +13,6 @@ test_that("epmc_ftxt returns", {
   expect_error(epmc_ftxt("2PMC3448176"))
   expect_error(epmc_ftxt("PMC3476"))
   expect_error(epmc_ftxt("3476"),
-    "Please provide a PMCID, i.e. ids starting with 'PMC'"
-    )
+    "Please provide one PMCID, i.e. id starting with 'PMC'"
+  )
 })


### PR DESCRIPTION
`epmc_ftxt()` only works with one PMCID. Currently, it attempts to execute with more than one PMCID and fails. In the example below 2 good PMCIDs are passed, first together then separately. Only when they are given separately does it work.

``` r
library(europepmc)

pmcids <- c("PMC10341083", "PMC10297282")
res1 <- epmc_ftxt(pmcids)
#> Warning in if (!grepl("^PMC", ext_id)) stop("Please provide a PMCID, i.e. ids
#> starting with 'PMC'"): the condition has length > 1 and only the first element
#> will be used
#> Request failed [404]. Retrying in 1 seconds...
#> Request failed [404]. Retrying in 4 seconds...
#> Error in epmc_ftxt(pmcids): Not Found (HTTP 404). Failed to retrieve full text..

res2 <- lapply(pmcids, epmc_ftxt)
length(res2)
#> [1] 2
```

<sup>Created on 2023-11-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The current documentation appears to indicate `epmc_ftxt()` can accept multiple inputs and the test to ensure `ext_id` is correctly formatted will pass as long as the first element of `ext_id` starts with 'PMC' (all others are ignored with a warning).

This PR depluralizes the documentation and updates the `ext_id` argument test to ensure it allows only one PMCID.
Loosely related to #38 and #37.

It seems like the documentation for `europepmc` functions are written in plural while primarily accepting singular inputs, so I totally understand if the documentation updates are dropped. The `ext_id` test update alone would still avoid malformed API requests and the need for user debugging.